### PR TITLE
Fixed wrapping and new line in menu function 

### DIFF
--- a/test.py
+++ b/test.py
@@ -28,38 +28,47 @@ from whiptail import Whiptail
 
 w = Whiptail(title="This is the title", backtitle="This is the backtitle", auto_exit=True)
 
-prompt = w.inputbox("Enter some text:")[0]
+prompt = w.inputbox("This is the first line. \n Newline test. Now, enter some text:")[0]
 print(f"You entered: '{prompt}'!")
 assert prompt == "Hello World"
 
-prompt_default = w.inputbox("Enter some text:", "-- Some Text ;)")[0]
+prompt_default = w.inputbox("This is the first line. \n Newline test. Now, enter some text:", "-- Some Text ;)")[0]
 print(f"You entered: '{prompt_default}'!")
 assert prompt_default == "-- Some Text ;)"
 
-prompt_password = w.inputbox("Enter a (pretend) password:", password=True)[0]
+prompt_password = w.inputbox(
+		"This is the first line. \n Newline test. Now, enter a (pretend) password:", password=True
+		)[0]
 print(f"Your password is: '{prompt_password}'!")
 assert prompt_password == "Password"
 
-msgbox = w.msgbox("This is an msgbox!")  # type: ignore[func-returns-value]
-print(f"Alert only returns the 't return anything, see: {alert}")
+msgbox = w.msgbox("This is an msgbox! \n This is a new line!")  # type: ignore[func-returns-value]
+print(f"msgbox doesn't return anything, see: {msgbox}")
 
 # view_file
 
-menu = w.menu("This is a menu.", ["Option 1", "Option 2", "Option 3", "Option 4"])[0]
+menu = w.menu(
+		"This is a menu. \n This is a new line in the menu", ["Option 1", "Option 2", "Option 3", "Option 4"]
+		)[0]
 print(f"You selected '{menu}'")
 assert menu == "Option 3"
 
 menu_descriptions = w.menu(
-		"This is a menu with descriptions.", [("Option 1", "Does Something"), ("Option 2", "Does Something Else")]
+		"This is a menu with descriptions. The rest of this is a very long string to test wrapping within the whiptail box. Here is more string to ensure it wraps on even the widest of monitors.",
+		[("Option 1", "Does Something"), ("Option 2", "Does Something Else")]
 		)[0]
 print(f"You selected '{menu_descriptions}'")
 assert menu_descriptions == "Option 2"
 
-radiolist = w.radiolist("Choose One", ["Spam, spam, spam, spam", "Egg", "Chips"])[0]
+radiolist = w.radiolist(
+		"This is the first line. \n Newline test. Choose One", ["Spam, spam, spam, spam", "Egg", "Chips"]
+		)[0]
 print(f"You selected: '{radiolist}'!")
 assert radiolist == ["Chips"]
 
-checklist = w.checklist("Choose Multiple", ["Spam, spam, spam, spam", "Egg", "Chips"])[0]
+checklist = w.checklist(
+		"This is the first line. \n Newline test. Choose Multiple", ["Spam, spam, spam, spam", "Egg", "Chips"]
+		)[0]
 checklist_str = "' and '".join(checklist)
 print(f"You selected: '{checklist_str}'!")
 print(checklist)

--- a/whiptail/__init__.py
+++ b/whiptail/__init__.py
@@ -297,7 +297,7 @@ class Whiptail:
 		:param msg: The message to display in the dialog box
 		"""
 
-		height_offset = 8 if msg else 7
+		height_offset = 9 if msg else 7
 
 		if self.height is None:
 			width, height = get_terminal_size()


### PR DESCRIPTION
This PR fixes the bug relating to specifically the menu function and not a. wrapping a long string in the `msg` parameter or b. rendering python `\n` in the string. [Bug](https://github.com/domdfcoding/whiptail/issues/41) #41 

Wrapping & Newline worked in all other functions.

I changed line `300`, adjusting the calc height value for  `if msg` from 8 to 9.

I also updated the test.py to include new lines or long strings in each function for testing purposes, but let me know if you'd like me to change the words and/or remove them completely since we now know it works.   