### PR TITLE
Ensure negative height is not given to `whiptail`

### DIFF
--- a/whiptail/__init__.py
+++ b/whiptail/__init__.py
@@ -306,7 +306,7 @@ class Whiptail:
 		else:
 			height = self.height
 
-		return [str(height - height_offset)]
+		return [str(max(0, height - height_offset))]
 
 	def menu(
 			self,


### PR DESCRIPTION
Starting with release [0.52.22](https://github.com/mlichvar/newt/releases/tag/r0-52-22), providing a negative height was leading to the items in a menu not being displayed

![image](https://user-images.githubusercontent.com/4998043/203173562-469fbc21-e2ee-44d7-b3cd-5cca1d134c96.png)

Same as https://github.com/marwano/whiptail/pull/2