### PR TITLE
Fix yesno prompt

### DIFF
--- a/whiptail/__init__.py
+++ b/whiptail/__init__.py
@@ -248,12 +248,14 @@ class Whiptail:
 		:return: :py:obj:`True` if the user selected ``yes``. :py:obj:`False` otherwise.
 		"""
 
+		# Ensure extra argument is not added unless needed
+		# When whiptail receives extra empty args it returns 255
+		extra_args = []
 		if default.lower() == "no":
-			defaultno = "--defaultno"
-		else:
-			defaultno = ''
+			extra_args.append("--defaultno")
 
-		return bool(self.run("yesno", msg, extra_args=[defaultno], exit_on=[255]).returncode)
+		# whiptail returns 0 for yes, 1 for no and bool translates this as 0=false, 1=true so invert the bool to match the docs above
+		return not bool(self.run("yesno", msg, extra_args=extra_args, exit_on=[255]).returncode)
 
 	def msgbox(self, msg: str) -> None:
 		"""


### PR DESCRIPTION
Previously when default was set to anything execept 'no' an extra empty arg was sent to whiptail resulting in a 255 return code and no prompt being displayed. When default was set to 'no' prompt was displayed by the returned boolean vlaues were opposite to described in the docs.

Now yesno fully works and complies with the documented behavior. Simple test script:

```
import whiptail
d = whiptail.Whiptail()

print(d.yesno("Answer=yes, Default=yes, default="yes"))
print(d.yesno("Answer=no,  Default=yes, default="yes"))
print(d.yesno("Answer=yes, Default=no,  default="no"))
print(d.yesno("Answer=no, Default=no,  default="no"))
```

Select the answer requested in the prompt and the result should be
```
True
False
True
False
```